### PR TITLE
Update manifests/lens.pp

### DIFF
--- a/manifests/lens.pp
+++ b/manifests/lens.pp
@@ -28,10 +28,10 @@ define augeas::lens (
 
   include augeas::base
 
-  $lens_dest = "${augeas::base::lens_dir}/${name}.aug"
-  $test_dest = "${augeas::base::lens_dir}/tests/test_${name}.aug"
+  $lens_dest = "${augeas::base::lens_dir}/dist/${name}.aug"
+  $test_dest = "${augeas::base::lens_dir}/dist/tests/test_${name}.aug"
 
-  file { "$lens_dest/dist":
+  file { "$lens_dest":
     ensure => $ensure,
     source => $lens_source,
   }


### PR DESCRIPTION
Set the path of custom lens to "$lens_dest/dist". At least on our ubuntu servers this was needed for augeas to catch it up. Otherwise we are getting 

```
 Loading failed for one or more files, see debug for /augeas//error output
```

If you want to specify the custom dir with _load_path_ on augeas resource then at least document this somewhere. Note that I couldn't test this on redhat based systems and it might differ there.
