### PR TITLE
Add stock_since to augeas::lens

### DIFF
--- a/manifests/lens.pp
+++ b/manifests/lens.pp
@@ -10,12 +10,15 @@ Parameters:
 - *ensure*: present/absent
 - *lens_source*: the source for the lens
 - *test_source*: optionally, the source for the test file.
+- *stock_since*: optionally, indicate in which version of Augeas
+  the lens became stock, so it will not be deployed above that version.
 
 Example usage:
 
   augeas::lens { 'networkmanager':
     lens_source => 'puppet:///modules/networkmanager/lenses/networkmanager.aug',
     test_source => 'puppet:///modules/networkmanager/lenses/test_networkmanager.aug',
+    stock_since => '1.0.0',
   }
 
 */
@@ -23,36 +26,39 @@ Example usage:
 define augeas::lens (
   $lens_source,
   $ensure=present,
-  $test_source=false
+  $test_source=false,
+  $stock_since=false,
 ) {
 
-  include augeas::base
+  if (!$stock_since or !versioncmp($::augeasversion, $stock_since)) {
+    include augeas::base
 
-  $lens_dest = "${augeas::base::lens_dir}/${name}.aug"
-  $test_dest = "${augeas::base::lens_dir}/tests/test_${name}.aug"
+    $lens_dest = "${augeas::base::lens_dir}/${name}.aug"
+    $test_dest = "${augeas::base::lens_dir}/tests/test_${name}.aug"
 
-  file { $lens_dest:
-    ensure => $ensure,
-    source => $lens_source,
-  }
-
-  exec { "Typecheck lens ${name}":
-    command     => "augparse -I ${augeas::base::lens_dir} ${lens_dest} || (rm -f ${lens_dest} && exit 1)",
-    refreshonly => true,
-    subscribe   => File[$lens_dest],
-  }
-
-  if $test_source {
-    file { $test_dest:
+    file { $lens_dest:
       ensure => $ensure,
-      source => $test_source,
-      notify => Exec["Test lens ${name}"],
+      source => $lens_source,
     }
 
-    exec { "Test lens ${name}":
-      command     => "augparse -I ${augeas::base::lens_dir} ${test_dest} || (rm -f ${lens_dest} && rm -f ${test_dest} && exit 1)",
+    exec { "Typecheck lens ${name}":
+      command     => "augparse -I ${augeas::base::lens_dir} ${lens_dest} || (rm -f ${lens_dest} && exit 1)",
       refreshonly => true,
-      subscribe   => File[$lens_dest, $test_dest],
+      subscribe   => File[$lens_dest],
+    }
+
+    if $test_source {
+      file { $test_dest:
+        ensure => $ensure,
+        source => $test_source,
+        notify => Exec["Test lens ${name}"],
+      }
+
+      exec { "Test lens ${name}":
+        command     => "augparse -I ${augeas::base::lens_dir} ${test_dest} || (rm -f ${lens_dest} && rm -f ${test_dest} && exit 1)",
+        refreshonly => true,
+        subscribe   => File[$lens_dest, $test_dest],
+      }
     }
   }
 }


### PR DESCRIPTION
Allows to simply deactivate lenses for new versions of Augeas.
