### PR TITLE
Better detection of ruby version

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,9 +12,10 @@ class augeas::params {
     }
 
     'Debian': {
-      $ruby_pkg = $::lsbdistcodename ? {
-        'wheezy' => 'libaugeas-ruby1.9.1',
-        default  => 'libaugeas-ruby1.8',
+      if versioncmp($::rubyversion, '1.9.1') >= 0 {
+        $ruby_pkg = 'libaugeas-ruby1.9.1'
+      } else {
+        $ruby_pkg = 'libaugeas-ruby1.8'
       }
       $augeas_pkgs = ['augeas-lenses', 'libaugeas0', 'augeas-tools']
     }


### PR DESCRIPTION
This changes the way the module determines the name of the `libaugeas-ruby` package on debian.

The previous method relied upon hard-coded release names. Aside from the fact that this requires the module to keep track of every single release name available, it also doesn't consider the possibility that ruby has been upgraded.

The solution is to use the `rubyversion` fact which is already provided and contains the version of ruby that puppet itself is running under.
