### PR TITLE
fix missing augparse cmd path

### DIFF
--- a/manifests/lens.pp
+++ b/manifests/lens.pp
@@ -48,6 +48,7 @@ define augeas::lens (
 
     exec { "Typecheck lens ${name}":
       command     => "augparse -I ${augeas::lens_dir} ${lens_dest} || (rm -f ${lens_dest} && exit 1)",
+      path        => "${augeas::augparse_path}",
       refreshonly => true,
       subscribe   => File[$lens_dest],
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@
 #
 class augeas::params {
   $lens_dir = '/usr/share/augeas/lenses'
+  $augparse_path = '/usr/bin'
 
   case $::osfamily {
     'RedHat': {


### PR DESCRIPTION
Add path attribute as puppet's `Exec` resource requires fully qualified command or path attribute.

Without this fix, adding new len ends up with following error
`[...] is not qualified and no path was specified. Please qualify the command or specify a path.`
