### PR TITLE
Add squeeze support. Fixes camptocamp/puppet-augeas #27

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,19 @@ class augeas::params {
       $augeas_pkgs = ['augeas-lenses', 'libaugeas0', 'augeas-tools']
     }
 
-    default:  { fail("Unsupported OS family: ${::osfamily}") }
+    default:  { 
+        case $::operatingsystem {
+            'Debian': {
+                if versioncmp($::rubyversion, '1.9.1') >= 0 {
+                    $ruby_pkg = 'libaugeas-ruby1.9.1'
+                } else {
+                    $ruby_pkg = 'libaugeas-ruby1.8'
+                }
+                $augeas_pkgs = ['augeas-lenses', 'libaugeas0', 'augeas-tools']
+            }
+            
+            default: {fail("Unsupported OS family: ${::osfamily}") }
+        }
+    }
   }
 }


### PR DESCRIPTION
This is a quick (and dirty maybe) solution to support Debian squeeze in your Puppet augeas module.
This fixes camptocamp/puppet-augeas #27.
Tell me if this is good for you.
