### PR TITLE
Ensure lenses are owned by root

### DIFF
--- a/manifests/lens.pp
+++ b/manifests/lens.pp
@@ -30,6 +30,12 @@ define augeas::lens (
     fail('You must declare the augeas class before using augeas::lens')
   }
 
+  File {
+    owner => 'root',
+    group => 'root',
+    mode => '0644',
+  }
+
   if (!$stock_since or versioncmp($::augeasversion, $stock_since) < 0) {
 
     validate_re(


### PR DESCRIPTION
This is necessary as lenses are fetched with file via puppet urls.
This leads to whoever ownes the files on the puppet master owns the
files on the node. This may lead to arbitrary users owning the lenses.
See http://projects.puppetlabs.com/issues/5240
