### PR TITLE
Update params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class augeas::params {
       $ruby_pkg = 'ruby-augeas'
       $augeas_pkgs = ['augeas', 'augeas-libs']
     }
-    
+
     'Suse': {
       $ruby_pkg = 'rubygem-ruby-augeas'
       $augeas_pkgs = ['augeas', 'augeas-lenses', 'libaugeas0' ]


### PR DESCRIPTION
This puppet module can be used on Suse flavors via adding two repos:
A) for recent puppet packages: https://build.opensuse.org/project/show/systemsmanagement:puppet (holding the actual rubygem-ruby-augeas package, official repos only include python-augeas _grrr_)
B) for dependency rubygems on SLES 11 add the SLE11-SDK repo available from Novell, openSuSE status unknown
