### PR TITLE
Module purges lens files installed by other packages (libvirt-bin in this case)

### DIFF
--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -8,7 +8,7 @@ class augeas::files {
   # ensure no file not managed by puppet ends up in there.
   file { $lens_dir:
     ensure       => directory,
-    purge        => true,
+    purge        => $::augeas::purge,
     force        => true,
     recurse      => true,
     recurselimit => 1,
@@ -27,7 +27,7 @@ class augeas::files {
 
   file { "${lens_dir}/tests":
     ensure  => directory,
-    purge   => true,
+    purge   => $::augeas::purge,
     force   => true,
     mode    => '0644',
     owner   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,10 +6,12 @@
 #   ['version']      - the desired version of Augeas
 #   ['ruby_version'] - the desired version of the Ruby bindings for Augeas
 #   ['lens_dir']     - the lens directory to use
+#   ['purge']        - whether to purge lens directories
 class augeas (
   $version = $augeas_version,
   $ruby_version = $augeas_ruby_version,
   $lens_dir = $augeas::params::lens_dir,
+  $purge = true,
 ) inherits augeas::params {
 
   class {'::augeas::packages': } ->


### PR DESCRIPTION
On Ubuntu 12.04 the package `libvirt-bin` installs the libvirt-related Augeas lenses to `/usr/share/augeas/lenses` (and the tests to `/usr/share/augeas/lenses/tests`). The puppet-augeas module, however, purges everything in that directory, including the lenses installed by the `libvirt-bin` package.

We can work around this by installing the libvirt lenses by means of `augeas::lens` from our own puppet-libvirt module, but I think overall it is not quite right to purge files properly and correctly installed by another, unrelated package.

Or is the libvirt package to blame here because it should have installed the lenses elsewhere?
