### PR TITLE
On Debian manage augeas-lenses before Augeas calls

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,5 +18,9 @@ class augeas (
   class {'::augeas::files': } ->
   Class['augeas']
 
-  Package['ruby-augeas'] -> Augeas <| |>
+  if $::osfamily == 'Debian' {
+    Package['ruby-augeas', 'augeas-lenses'] -> Augeas <| |>
+  } else {
+    Package['ruby-augeas'] -> Augeas <| |>
+  }
 }


### PR DESCRIPTION
On Debian osfamily make sure the augeas-lenses package is installed and
ready before invoking Augeas. Fixes #33.
