### PR TITLE
The package version of the augeas library does not map to the ruby version

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -8,7 +8,7 @@ class augeas::packages {
   }
 
   package { 'ruby-augeas':
-    ensure => $::augeas::ruby_version,
+    ensure => present,
     name   => $::augeas::params::ruby_pkg,
   }
 }

--- a/spec/hosts/simple_debian_squeeze_spec.rb
+++ b/spec/hosts/simple_debian_squeeze_spec.rb
@@ -54,7 +54,7 @@ describe 'simple_debian_squeeze' do
       :ensure => '1.2.3'
     ) }
     it { should contain_package('ruby-augeas').with(
-      :ensure => '3.2.1',
+      :ensure => 'present',
       :name   => 'libaugeas-ruby1.8'
     ) }
   end

--- a/spec/hosts/simple_debian_wheezy_spec.rb
+++ b/spec/hosts/simple_debian_wheezy_spec.rb
@@ -46,7 +46,7 @@ describe 'simple_debian_wheezy' do
       :ensure => '1.2.3'
     ) }
     it { should contain_package('ruby-augeas').with(
-      :ensure => '3.2.1',
+      :ensure => 'present',
       :name   => 'libaugeas-ruby1.9.1'
     ) }
   end

--- a/spec/hosts/simple_redhat_spec.rb
+++ b/spec/hosts/simple_redhat_spec.rb
@@ -40,7 +40,7 @@ describe 'simple_redhat' do
       :ensure => '1.2.3'
     ) }
     it { should contain_package('ruby-augeas').with(
-      :ensure => '3.2.1',
+      :ensure => 'present',
       :name   => 'ruby-augeas'
     ) }
   end


### PR DESCRIPTION
Given the example below, the package versions for libaugeas-ruby, libaugeas-ruby1.8, and libaugeas-ruby1.9 is 0.5.2 and has no relationship to a specified Ruby version (this is handled by the package name prefix)

http://packages.ubuntu.com/search?keywords=libaugeas-ruby&searchon=names&suite=trusty&section=all.

It would be better to use the `present`, `installed` or `latest` ensure directive.
