### PR TITLE
Include augeas 'super' class when not declared.

### DIFF
--- a/manifests/lens.pp
+++ b/manifests/lens.pp
@@ -30,9 +30,7 @@ define augeas::lens (
   $test_source  = undef,
   $stock_since  = false,
 ) {
-  if !defined(Class['augeas']) {
-    fail('You must declare the augeas class before using augeas::lens')
-  }
+  include ::augeas
 
   if $lens_source != undef {
     if $lens_content != undef {


### PR DESCRIPTION
This change should be retrocompatible with already declared augeas classes with parameters and solves problems that I found using the postfix module.

The point is you should'nt have to instance augeas class because you are using postfix. It should do it itself when needed.
