### PR TITLE
Initial support for Puppet 4 AIO package version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,11 +14,17 @@ class augeas (
   $purge        = true,
 ) inherits augeas::params {
 
-  class {'::augeas::packages': } ->
-  class {'::augeas::files': } ->
-  Class['augeas']
+  if versioncmp($::puppetversion, '4.0.0') >= 0 {
+    class {'::augeas::files': } ->
+    Class['augeas']
+  } else {
+    class {'::augeas::packages': } ->
+    class {'::augeas::files': } ->
+    Class['augeas']
 
-  # lint:ignore:spaceship_operator_without_tag
-  Package['ruby-augeas', $augeas::params::augeas_pkgs] -> Augeas <| |>
-  # lint:endignore
+    # lint:ignore:spaceship_operator_without_tag
+    Package['ruby-augeas', $augeas::params::augeas_pkgs] -> Augeas <| |>
+    # lint:endignore
+  }
+
 }

--- a/manifests/lens.pp
+++ b/manifests/lens.pp
@@ -60,8 +60,14 @@ define augeas::lens (
     mode => '0644',
   }
 
-  Exec {
-    path => $::path,
+  if versioncmp($::puppetversion, '4.0.0') >= 0 {
+    Exec {
+      path => "${::path}:/opt/puppetlabs/puppet/bin",
+    }
+  } else {
+    Exec {
+      path => $::path,
+    }
   }
 
   if (!$stock_since or versioncmp($::augeasversion, $stock_since) < 0) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,12 @@
 # Default parameters for the Augeas module
 #
 class augeas::params {
-  $lens_dir = '/usr/share/augeas/lenses'
+
+  if versioncmp($::puppetversion, '4.0.0') >= 0 {
+    $lens_dir = '/opt/puppetlabs/puppet/share/augeas/lenses'
+  } else {
+    $lens_dir = '/usr/share/augeas/lenses'
+  }
 
   case $::osfamily {
     'RedHat': {


### PR DESCRIPTION
The Puppet 4 AIO package version ships with it's own version of augeas and ruby in /opt/puppetlabs.
To support this some paths need to be changed and dependency packages should not be installed anymore.