### PR TITLE
Allow setting package name of ruby augeas bindings

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,13 +4,15 @@
 #
 # Parameters:
 #   ['version']      - the desired version of Augeas
+#   ['ruby_package'] - the desired package name of the Ruby bindings for Augeas
 #   ['ruby_version'] - the desired version of the Ruby bindings for Augeas
 #   ['lens_dir']     - the lens directory to use
 #   ['purge']        - whether to purge lens directories
 class augeas (
   $version      = present,
+  $ruby_package = $::augeas::params::ruby_pkg,
   $ruby_version = present,
-  $lens_dir     = $augeas::params::lens_dir,
+  $lens_dir     = $::augeas::params::lens_dir,
   $purge        = true,
 ) inherits augeas::params {
 

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -9,6 +9,6 @@ class augeas::packages {
 
   package { 'ruby-augeas':
     ensure => $::augeas::ruby_version,
-    name   => $::augeas::params::ruby_pkg,
+    name   => $::augeas::ruby_package,
   }
 }


### PR DESCRIPTION
Required when using a non-standard ruby runtime, for example SCL's on Redhat.