### PR TITLE
Add support for Amazon Linux AMI

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,7 +7,11 @@ class augeas::params {
 
   case $::osfamily {
     'RedHat': {
-      $ruby_pkg = 'ruby-augeas'
+      $ruby_pkg = $::operatingsystem ? {
+        # Amazon Linux AMI (2014.09 and 2015.03) uses ruby 2.0
+        'Amazon' => 'ruby20-augeas',
+        default => 'ruby-augeas'
+      }
       $augeas_pkgs = ['augeas', 'augeas-libs']
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -46,7 +46,15 @@
         "5",
         "6"
       ]
+    },
+    {
+      "operatingsystem": "Amazon",
+      "operatingsystemrelease": [
+        "2014.09",
+        "2015.03"
+      ]
     }
+
   ],
   "puppet_version": [
     "2.7",


### PR DESCRIPTION
This PR adds support for Amazon Linux AMI, which uses ruby version 2.0 by default. 