### PR TITLE
Fix package installation on more recent Ubuntu variants

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 group :development, :unit_tests do
   gem 'rake',                                              :require => false
   gem 'rspec', '< 3.2',                                    :require => false if RUBY_VERSION =~ /^1.8/
-  gem 'rspec-puppet',                                      :require => false
+  gem 'rspec-puppet', '2.3.0'                              :require => false
   gem 'puppetlabs_spec_helper',                            :require => false
   gem 'metadata-json-lint',                                :require => false
   gem 'puppet-lint',                                       :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 group :development, :unit_tests do
   gem 'rake',                                              :require => false
   gem 'rspec', '< 3.2',                                    :require => false if RUBY_VERSION =~ /^1.8/
-  gem 'rspec-puppet', '2.3.0'                              :require => false
+  gem 'rspec-puppet', '2.3.0',                             :require => false
   gem 'puppetlabs_spec_helper',                            :require => false
   gem 'metadata-json-lint',                                :require => false
   gem 'puppet-lint',                                       :require => false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,7 @@ class augeas::params {
 
   if versioncmp($::puppetversion, '4.0.0') >= 0 {
     $lens_dir = '/opt/puppetlabs/puppet/share/augeas/lenses'
-  } elsif (defined('$is_pe') and str2bool("${::is_pe}")) { # lint:ignore:only_variable_string
+  } elsif (defined('$is_pe') and str2bool($::is_pe)) { # lint:ignore:only_variable_string
     # puppet enterpise has a different lens location
     $lens_dir = '/opt/puppet/share/augeas/lenses'
   } else {
@@ -37,7 +37,7 @@ class augeas::params {
 
     'Debian': {
       if ( ($::operatingsystem == 'Ubuntu') and (versioncmp($::operatingsystemrelease, '15.10') >= 0 ) ) {
-      	$ruby_pkg = 'ruby-augeas'
+        $ruby_pkg = 'ruby-augeas'
       }
       else {
         if versioncmp($::rubyversion, '1.9.1') >= 0 {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,12 +40,15 @@ class augeas::params {
         $ruby_pkg = 'ruby-augeas'
       }
       else {
-        if versioncmp($::rubyversion, '1.9.1') >= 0 {
-          $ruby_pkg = 'libaugeas-ruby1.9.1'
-        } else {
-          $ruby_pkg = 'libaugeas-ruby1.8'
+        if versioncmp($::rubyversion, '2.3.0') == 0 {
+          $ruby_pkg = 'ruby-augeas'
+          } elsif 
+          versioncmp($::rubyversion, '1.9.1') >= 0 {
+            $ruby_pkg = 'libaugeas-ruby1.9.1'
+          } else {
+            $ruby_pkg = 'libaugeas-ruby1.8'
+          }
         }
-      }
       $augeas_pkgs = ['augeas-lenses', 'libaugeas0', 'augeas-tools']
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,8 +36,8 @@ class augeas::params {
     }
 
     'Debian': {
-      if ($::operatingsystem == 'Ubuntu') {
-	$ruby_pkg = 'ruby-augeas'
+      if ( ($::operatingsystem == 'Ubuntu') and (versioncmp($::operatingsystemrelease, '15.10') >= 0 ) ) {
+      	$ruby_pkg = 'ruby-augeas'
       }
       else {
         if versioncmp($::rubyversion, '1.9.1') >= 0 {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,10 +36,15 @@ class augeas::params {
     }
 
     'Debian': {
-      if versioncmp($::rubyversion, '1.9.1') >= 0 {
-        $ruby_pkg = 'libaugeas-ruby1.9.1'
-      } else {
-        $ruby_pkg = 'libaugeas-ruby1.8'
+      if ($::operatingsystem == 'Ubuntu') {
+	$ruby_pkg = 'ruby-augeas'
+      }
+      else {
+        if versioncmp($::rubyversion, '1.9.1') >= 0 {
+          $ruby_pkg = 'libaugeas-ruby1.9.1'
+        } else {
+          $ruby_pkg = 'libaugeas-ruby1.8'
+        }
       }
       $augeas_pkgs = ['augeas-lenses', 'libaugeas0', 'augeas-tools']
     }


### PR DESCRIPTION
On at least Ubuntu 15.10 the module fails, as the augeas-ruby-package has been renamed:

E: Unable to locate package libaugeas-ruby1.9.1
E: Couldn't find any package by regex 'libaugeas-ruby1.9.1'
Error: /Stage[main]/Augeas::Packages/Package[ruby-augeas]/ensure: change from purged to present failed: Executio
n of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install libaugeas-ruby1.9.1' returned 100: Readi
ng package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package libaugeas-ruby1.9.1
E: Couldn't find any package by regex 'libaugeas-ruby1.9.1'

The package now is called ruby-augeas. The pull-request only addresses 15.10 as that the first Ubuntu with that package availabke, according to http://packages.ubuntu.com/search?keywords=ruby-augeas&searchon=names&suite=wily&section=all.
