### PR TITLE
Remove ordering that puts Augeas packages before Augeas resources

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,10 +25,6 @@ class augeas (
     class {'::augeas::packages': } ->
     class {'::augeas::files': } ->
     anchor { 'augeas::end': }
-
-    # lint:ignore:spaceship_operator_without_tag
-    Package['ruby-augeas', $augeas::params::augeas_pkgs] -> Augeas <| |>
-    # lint:endignore
   }
 
 }


### PR DESCRIPTION
Remove ordering that puts Augeas packages before Augeas resources

ruby-augeas is a dependency of puppet, so it will already be installed

Relates to #56

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/camptocamp/puppet-augeas/58)

<!-- Reviewable:end -->
