### PR TITLE
ruby-augeas instead of libaugeas-ruby

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,7 +36,10 @@ class augeas::params {
     }
 
     'Debian': {
-      if versioncmp($::rubyversion, '1.9.1') >= 0 {
+      if versioncmp($::rubyversion, '2.1.0') >= 0 {
+        $ruby_pkg = 'ruby-augeas'
+      }
+      elsif versioncmp($::rubyversion, '1.9.1') >= 0 {
         $ruby_pkg = 'libaugeas-ruby1.9.1'
       } else {
         $ruby_pkg = 'libaugeas-ruby1.8'


### PR DESCRIPTION
root@x220:~# ruby --version
ruby 2.1.5p273 (2014-11-13) [x86_64-linux-gnu]
root@x220:~# dpkg -l | grep ruby-augeas
ii  ruby-augeas                                   1:0.5.0-3build1                            amd64        Augeas bindings for the Ruby language
root@x220:~# dpkg -l | grep libaugeas-ruby



$ ruby --version
ruby 1.9.3p484 (2013-11-22 revision 43786) [x86_64-linux]
$ dpkg -l | grep ruby-augeas
ii  libaugeas-ruby                      0.5.0-2                              all          Transitional package for ruby-augeas
ii  libaugeas-ruby1.9.1                 0.5.0-2                              all          Transitional package for ruby-augeas
ii  ruby-augeas                         0.5.0-2                              amd64        Augeas bindings for the Ruby language