### PR TITLE
Allow Puppet 6 and remove stdlib dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,0 @@
-fixtures:
-  repositories:
-    "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-  symlinks:
-    "augeas": "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,18 +17,13 @@ class augeas (
 ) inherits augeas::params {
 
   if versioncmp($::puppetversion, '4.0.0') >= 0 {
-    anchor { 'augeas::begin': }
-    -> class {'::augeas::files': }
-    -> anchor { 'augeas::end': }
+    contain 'augeas::files'
   } else {
-    anchor { 'augeas::begin': }
-    -> class {'::augeas::packages': }
-    -> class {'::augeas::files': }
-    -> anchor { 'augeas::end': }
+    contain 'augeas::packages'
+    contain 'augeas::files'
+    Class['augeas::packages'] -> Class['augeas::files']
 
-    # lint:ignore:spaceship_operator_without_tag
-    Package['ruby-augeas', $augeas::params::augeas_pkgs] -> Augeas <| |>
-    # lint:endignore
+    Package['ruby-augeas', $augeas::params::augeas_pkgs] -> Augeas <| |> # lint:ignore:spaceship_operator_without_tag
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,16 +8,11 @@
   "project_page": "https://github.com/camptocamp/puppet-augeas",
   "issues_url": "https://github.com/camptocamp/puppet-augeas/issues",
   "description": "Augeas Module for Puppet",
-  "dependencies": [
-    {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.2.0 < 6.0.0"
-    }
-  ],
+  "dependencies": [],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 6.0.0"
+      "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
By replacing `anchor` with `contain` (which has been available since
puppet 3.4), the dependency on puppetlabs/stdlib can be removed
altogether.