### PR TITLE
Allow customizing files owner and group

### DIFF
--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -1,0 +1,2 @@
+---
+augeas::files_group: "wheel"

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -3,6 +3,8 @@
 # Sets up directories and files for Augeas
 #
 class augeas::files {
+  include augeas
+
   $lens_dir = $augeas::lens_dir
 
   # ensure no file not managed by puppet ends up in there.
@@ -13,16 +15,16 @@ class augeas::files {
     recurse      => true,
     recurselimit => 1,
     mode         => '0644',
-    owner        => 'root',
-    group        => 'root',
+    owner        => $augeas::files_owner,
+    group        => $augeas::files_group,
   }
 
   file { "${lens_dir}/dist":
     ensure => directory,
     purge  => false,
     mode   => '0644',
-    owner  => 'root',
-    group  => 'root',
+    owner  => $augeas::files_owner,
+    group  => $augeas::files_group,
   }
 
   file { "${lens_dir}/tests":
@@ -30,7 +32,7 @@ class augeas::files {
     purge  => $::augeas::purge,
     force  => true,
     mode   => '0644',
-    owner  => 'root',
-    group  => 'root',
+    owner  => $augeas::files_owner,
+    group  => $augeas::files_group,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,8 @@
 #   ['lens_dir']     - the lens directory to use
 #   ['purge']        - whether to purge lens directories
 class augeas (
+  String $files_owner = 'root',
+  String $files_group = 'root',
   $version      = present,
   $ruby_package = $::augeas::params::ruby_pkg,
   $ruby_version = present,

--- a/manifests/lens.pp
+++ b/manifests/lens.pp
@@ -53,8 +53,8 @@ define augeas::lens (
   }
 
   File {
-    owner => 'root',
-    group => 'root',
+    owner => $augeas::files_owner,
+    group => $augeas::files_group,
     mode => '0644',
   }
 


### PR DESCRIPTION
Use this to properly manage group on FreeBSD: we do not have a "root"
group, the group with gid==0 is named "wheel".