### PR TITLE
Avoid legacyfact augeasversion

### DIFF
--- a/manifests/lens.pp
+++ b/manifests/lens.pp
@@ -58,7 +58,7 @@ define augeas::lens (
     mode => '0644',
   }
 
-  if (!$stock_since or versioncmp(String($::augeasversion), $stock_since) < 0) {
+  if (!$stock_since or versioncmp(String($facts['augeas']['version']), $stock_since) < 0) {
     assert_type(Pattern[/^\/.*/], $augeas::lens_dir)
 
     $lens_name = "${name}.aug"


### PR DESCRIPTION
Some new facts sets in facterdb do not contain the
legacyfact augeasversion.

Switch to `augeas.version`