### PR TITLE
drop EOL Ubuntu10.04, 12.04, 14.04, add Ubuntu16.04, 18.04, 20.04, 22.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -24,9 +24,10 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "10.04",
-        "12.04",
-        "14.04"
+        "16.04",
+        "18.04",
+        "20.04",
+        "22.04"
       ]
     },
     {


### PR DESCRIPTION
The current module announces in `metadata.json` to support Ubuntu10.04, 12.04, 14.04. I used it for 16.04. I use it for 18.04 et 20.04. I am preparing my infrastructure code for 22.04. This module is used by `puppet-postfix` and all looks working well also on 22.04.

I propose this PR to be clear about supported OSes that i use and so i can really test.
